### PR TITLE
Fix: allowing renaming of filter windows

### DIFF
--- a/pywk99/__init__.py
+++ b/pywk99/__init__.py
@@ -3,6 +3,9 @@ Wavenumber-frequency analysis in Python.
 
 Changelog
 ---------
+Jun 13, 2025: Version 0.4.4
+    - Allowing renaming of filter windows
+
 Apr 8, 2025: Version 0.4.3
     - Adding support for healpix
 
@@ -70,4 +73,4 @@ Sep 14, 2023: Version 0.1.0
     - Several bugs where detected and corrected with the tests.
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/pywk99/filter/window.py
+++ b/pywk99/filter/window.py
@@ -9,10 +9,12 @@ from pywk99.waves import LinearWave
 
 DISPERSION_CURVE_POINTS = 100
 
+
 class FilterPoint(Point):
     """See shapely.geometry.Point."""
 
-@dataclass(frozen=True)
+
+@dataclass
 class FilterWindow:
     name: str
     polygon: Union[Polygon, MultiPolygon]

--- a/tests/test_filter_window.py
+++ b/tests/test_filter_window.py
@@ -80,3 +80,8 @@ def test_mjo_window_function():
 def test_tropical_depression_window_function():
     td_window = get_tropical_depression_window()
     assert isinstance(td_window, FilterWindow)
+
+
+def test_window_name_can_be_changed(filter_window):
+    filter_window.name = "new_name"
+    assert filter_window.name == "new_name"


### PR DESCRIPTION
A small fix that allows to rename filter windows. For instance:

```python
    wave_type = "inertio_gravity"
    w_min, w_max = (0.3, 0.8)
    k_min, k_max = (-15, -1)
    h_min, h_max = (12, 50)         #Equivalent depths
    westward_inertio_gravity = get_wave_filter_window(wave_type,
                                                      k_min, k_max,
                                                      w_min, w_max,
                                                      h_min, h_max)       
    westward_inertio_gravity.name = "westward_inertio_gravity"
```

